### PR TITLE
GolangによるAPIサーバの環境構築（イニシャライズ）

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3"
+services:
+  api:
+    container_name: koukaten2021_api
+    build: ./go
+    volumes:
+      - ./go/app:/app
+    ports:
+      - "8081:80"
+    networks:
+      - koukaten2021_network
+networks:
+  koukaten2021_network:
+    external: true

--- a/go/Dockerfile
+++ b/go/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:alpine
+WORKDIR /app
+EXPOSE 80
+EXPOSE 443
+
+RUN apk --update add tzdata&&\
+    cp  /usr/share/zoneinfo/Asia/Tokyo /etc/localtime&&\
+    apk del tzdata&&\
+    rm -rf /var/cache/apk/*
+
+CMD ["go","run","main.go"]

--- a/go/app/go.mod
+++ b/go/app/go.mod
@@ -1,0 +1,3 @@
+module set1.ie.aitech.ac.jp/koukaten2021
+
+go 1.16

--- a/go/app/main.go
+++ b/go/app/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"log"
+	"net/http"
+)
+
+func hoge(http.ResponseWriter, *http.Request) {
+	log.Print("Accessed /")
+}
+
+func main() {
+	log.Print("hello world\n")
+	http.HandleFunc("/", hoge)
+
+	http.ListenAndServe(":80", nil)
+}


### PR DESCRIPTION
以後，`docker-compose up`をすると，`http://localhost:8081`からAPIサーバにアクセスできるようになります． 
また，`go mod init set1.ie.aitech.ac.jp/koukaten2021`を行いました． 当プロジェクトにおけるGolang用のモジュール名は`set1.ie.aitech.ac.jp/koukaten2021`となります． 
main.goにおける処理は，サーバ を立ち上げた時と，/にアクセスした時に簡単なログを表示するのみです．