### PR TITLE
Python用APIサーバの構築

### DIFF
--- a/python/detect.py
+++ b/python/detect.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import argparse
 import time
 from pathlib import Path
@@ -243,7 +245,7 @@ if __name__ == '__main__':
     parser.add_argument('--hide-conf', default=False,
                         action='store_true', help='hide confidences')
     opt = parser.parse_args()
-    check_requirements(exclude=('tensorboard', 'pycocotools', 'thop'))
+    # check_requirements(exclude=('tensorboard', 'pycocotools', 'thop'))
 
     with torch.no_grad():
         if opt.update:  # update all models (to fix SourceChangeWarning)

--- a/python/server.py
+++ b/python/server.py
@@ -1,0 +1,29 @@
+import re
+from wsgiref.simple_server import make_server
+
+import json
+import subprocess
+
+def app(environ, start_response):
+    command = ['python3', 'detect.py']
+    res = subprocess.run(command, stdout=subprocess.PIPE)
+    if res.returncode != 0:
+        message = "ERROR: Failed to run detect.py."
+        status = '500 INTERNAL SERVER ERROR'
+        headers = [('Access-Control-Allow-Origin', '*')]
+        start_response(status, headers)
+        print(message)
+        return [json.dumps({'status': status, 'message': message}).encode("utf-8")]
+
+    res = re.sub(r"\D", "", res.stdout.decode())
+    status = '200 OK'
+    headers = [
+        ('Content-type', 'application/json; charset=utf-8'),
+        ('Access-Control-Allow-Origin', '*'),
+    ]
+    start_response(status, headers)
+    return [json.dumps({'status': status, 'people': res}).encode("utf-8")]
+
+with make_server('', 8082, app) as httpd:
+    print("Serving on port 8082...")
+    httpd.serve_forever()

--- a/python/server.py
+++ b/python/server.py
@@ -10,7 +10,10 @@ def app(environ, start_response):
     if res.returncode != 0:
         message = "ERROR: Failed to run detect.py."
         status = '500 INTERNAL SERVER ERROR'
-        headers = [('Access-Control-Allow-Origin', '*')]
+        headers = [
+            ('Content-type', 'application/json; charset=utf-8'), 
+            ('Access-Control-Allow-Origin', '*')
+        ]
         start_response(status, headers)
         print(message)
         return [json.dumps({'status': status, 'message': message}).encode("utf-8")]


### PR DESCRIPTION
Goによるサーバからカメラ部分を切り離すために，カメラ部分専用のAPIサーバを立てるスクリプトを書きました．

今後，GoからこのサーバのAPIを叩くことによって，detect.pyの実行を実現します．

ルート（"/"）にアクセスすることによって実行されます．`curl http://localhost:8082/`

成功時のjsonは以下の通りです(swagger未定義): 
```
{
　'status': status,
　'people': res
}
```
失敗時のjsonは以下の通りです(swagger未定義): 
```
{
　'status': status,
　'message': message
}
```
では，よろしくお願いします．