### PR TITLE
Makefileの削減

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,32 +6,9 @@ CAMERA_SERVER_DIR=python/
 CAMERA_SERVER_SCRIPT=server.py
 CAMERA_SERVER_REQUIREMENTS=requirements.txt
 
-# サービスの構築及び立ち上げ
-## バックグラウンド
+# サービスの構築
 up-build:
-	docker compose up -d --build
-	@make up-camera
-
-up-api:
-	docker compose up -d --build $(API_SERVICE)
-	@make up-camera
-
-up-database:
-	docker compose up -d --build $(DB_SERVICE)
-	@make up-camera
-
-## フォアグラウンド
-up-build-f:
-	docker compose up --build &
-	@make up-camera-f
-
-up-api-f:
-	docker compose up --build $(API_SERVICE) &
-	@make up-camera-f
-
-up-database-f:
-	docker compose up -d --build $(DB_SERVICE) &
-	@make up-camera-f
+	docker compose build
 
 # コンテナ立ち上げ
 ## バックグラウンド
@@ -73,49 +50,8 @@ down:
 	docker compose down
 	@make stop-camera
 
-## ボリュームも消す
-down-v:
-	docker compose down -v
-	@make stop-camera
-
-## Composeファイルで定義していないサービス用のコンテナも削除
-down-ro:
-	docker compose down --remove-orphans
-	@make stop-camera
-
 # サービスの再起動
 restart:
 	docker-compose restart
 	@make stop-camera
 	@make up-camera
-
-# その他
-## データベースコンテナに入る
-sh-database:
-	docker exec -it $(DB) bash
-
-## APIコンテナに入る
-sh-api:
-	docker exec -it $(API) sh
-
-## 全てのサービスのログを出力する
-logs:
-	docker compose logs
-
-## コンテナ一覧
-ps:
-	docker compose ps
-
-## イメージの一覧を表示
-images:
-	docker compose images
-
-## 全て消し
-destroy:
-	docker compose down --volumes --remove-orphans
-	@make stop-camera
-
-## イメージも消す
-destroy-with-image:
-	docker compose down --rmi all --volumes --remove-orphans
-	@make stop-camera

--- a/Makefile
+++ b/Makefile
@@ -2,53 +2,47 @@ CAMERA_DIR=python/
 CAMERA_SERVER_SCRIPT=server.py
 CAMERA_SERVER_REQUIREMENTS=requirements.txt
 
-# サービスの構築
-build:
+build: ## サービスの構築
 	docker compose build
 	pip install -r $(CAMERA_DIR)$(CAMERA_SERVER_REQUIREMENTS)
 
-# コンテナ立ち上げ
-## バックグラウンド
-up:
+up: ## サービス立ち上げ(バックグラウンド)
 	docker compose up -d
 	@make up-camera
 	
-## フォアグラウンド
-up-f:
+up-f: ## サービス立ち上げ(フォアグラウンド)
 	docker compose up &
 	@make up-camera-f
 
-# カメラサーバ立ち上げ
-## バックグラウンド
-up-camera:
-	python3 $(CAMERA_DIR)$(CAMERA_SERVER_SCRIPT) & > /dev/null 2>&1
-
-## フォアグラウンド
-up-camera-f:
-	python3 $(CAMERA_DIR)$(CAMERA_SERVER_SCRIPT)
-
-# 停止系
-## 全てのサービスを停止する
-stop:
+stop: ## サービスを停止
 	docker-compose stop
 	@make stop-camera
 
-## コンテナを kill (強制停止)
-kill:
+kill: ## サービスを強制停止
 	docker-compose kill
 	@make stop-camera
 
-## カメラサーバのみ停止する
-stop-camera:
-	ps | grep server.py | head -1 | awk '{print $$1}' | xargs kill
-
-## コンテナ・ネットワークの停止と削除
-down:
+down: ## サービスの停止とコンテナの削除
 	docker compose down
 	@make stop-camera
 
-# サービスの再起動
-restart:
+restart: ## サービスの再起動
 	docker-compose restart
 	@make stop-camera
 	@make up-camera
+
+help: ## ヘルプを表示
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+# カメラ関連
+## カメラサーバ立ち上げ(バックグラウンド)
+up-camera:
+	python3 $(CAMERA_DIR)$(CAMERA_SERVER_SCRIPT) & > /dev/null 2>&1
+
+## カメラサーバ立ち上げ(フォアグラウンド)
+up-camera-f:
+	python3 $(CAMERA_DIR)$(CAMERA_SERVER_SCRIPT)
+
+## カメラサーバ停止
+stop-camera: 
+	ps | grep server.py | head -1 | awk '{print $$1}' | xargs kill

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,4 @@
-API=koukaten2021_api
-DB=koukaten2021_mysql
-API_SERVICE=api
-DB_SERVICE=mysql
-CAMERA_SERVER_DIR=python/
+CAMERA_DIR=python/
 CAMERA_SERVER_SCRIPT=server.py
 CAMERA_SERVER_REQUIREMENTS=requirements.txt
 
@@ -24,11 +20,11 @@ up-f:
 # カメラサーバ立ち上げ
 ## バックグラウンド
 up-camera:
-	python3 $(CAMERA_SERVER_DIR)$(CAMERA_SERVER_SCRIPT) & > /dev/null 2>&1
+	python3 $(CAMERA_DIR)$(CAMERA_SERVER_SCRIPT) & > /dev/null 2>&1
 
 ## フォアグラウンド
 up-camera-f:
-	python3 $(CAMERA_SERVER_DIR)$(CAMERA_SERVER_SCRIPT)
+	python3 $(CAMERA_DIR)$(CAMERA_SERVER_SCRIPT)
 
 # 停止系
 ## 全てのサービスを停止する

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,9 @@ CAMERA_SERVER_SCRIPT=server.py
 CAMERA_SERVER_REQUIREMENTS=requirements.txt
 
 # サービスの構築
-up-build:
+build:
 	docker compose build
+	pip install -r $(CAMERA_DIR)$(CAMERA_SERVER_REQUIREMENTS)
 
 # コンテナ立ち上げ
 ## バックグラウンド


### PR DESCRIPTION
Makefileの不要なコマンドを削除しました．  
  
読みやすさを向上させるため，主にあまり使わないコマンドを削除しました．また，Makefileのあるディレクトリにわざわざ移動してから実行するよりも，元のコマンドを覚えた方が早いコマンドについても削除しています．実行の重要度が高く，元のコマンドの意味をよく理解してから実行した方が良いコマンドについても削除しています．  
  
といっても，最近のシェルは補完もよく効くので，一度打ったコマンドはそもそも覚える必要すらなく，タイプの手間も少ないはずです．あと，自動化が流行っているとはいえ，dockerの基本的なコマンドぐらいは覚えてもいいでしょう．  
  
ついでに，help機能もつけておきました．
  
では，よろしくお願いします．