### PR TITLE
フロントエンドの全体的なリファクタリング / バックエンドとの通信の実行

### DIFF
--- a/nuxt/components/showgraph.vue
+++ b/nuxt/components/showgraph.vue
@@ -1,7 +1,7 @@
 <!--グラフ表示コンポーネント-->
 <template>
   <v-row justify="center">
-    <v-col :cols="width">
+    <v-col :cols="cardwidth">
       <v-card outlined>
         <v-container>
           <v-row>
@@ -103,12 +103,17 @@ const graphBackGroundColor = [
 
 export default {
   name: 'ShowGraph',
+
   components: {
     Chart,
   },
+
+  props: ['cardwidth'],
+
   data: () => ({
     selectedDoW: '',
   }),
+
   computed: {
     datasets: function () {
       let backGroundColors = this.graphValue.map((element) => {
@@ -173,20 +178,6 @@ export default {
             0,
           ]
         // value = this.$store.state.sunday
-      }
-    },
-    width: function () {
-      switch (this.$vuetify.breakpoint.name) {
-        case 'xs':
-          return 11
-        case 'sm':
-          return 8
-        case 'md':
-          return 8
-        case 'lg':
-          return 8
-        case 'xl':
-          return 8
       }
     },
   },

--- a/nuxt/components/showgraph.vue
+++ b/nuxt/components/showgraph.vue
@@ -162,6 +162,8 @@ export default {
     this.graphBorderColor = graphBorderColor
     this.graphBackGroundColor = graphBackGroundColor
 
+    this.$store.dispatch('getGraphVal')
+
     let date = new Date()
     this.selectedDoW = this.dow[date.getDay()]
   },

--- a/nuxt/components/showgraph.vue
+++ b/nuxt/components/showgraph.vue
@@ -1,26 +1,37 @@
 <!--グラフ表示コンポーネント-->
 <template>
-  <v-row justify="center" align-content="center">
+  <v-row justify="center">
     <v-col :cols="width">
-      <v-card class="justify-center" outlined>
-        <v-col cols="12" sm="4">
-          <h3>【人数予想】</h3>
-          <v-select
-            v-model="selectedDoW"
-            :items="dow"
-            label="day of week"
-            outlined
-          ></v-select>
-        </v-col>
-        <v-row align="center">
-          <v-col align="center">
-            <Chart
-              :datasets="datasets"
-              :labels="graphLabels"
-              :options="graphOptions"
-            />
-          </v-col>
-        </v-row>
+      <v-card outlined>
+        <v-container>
+          <v-row>
+            <v-card-text
+              class="font-weight-bold mb-n2"
+              style="font-size: 1.25rem"
+              >【人数予想】</v-card-text
+            >
+          </v-row>
+          <v-row>
+            <v-col cols="12" sm="4">
+              <v-select
+                v-model="selectedDoW"
+                :items="dow"
+                label="day of week"
+                outlined
+                class="mb-n8"
+              ></v-select>
+            </v-col>
+          </v-row>
+          <v-row>
+            <v-col cols="12">
+              <Chart
+                :datasets="datasets"
+                :labels="graphLabels"
+                :options="graphOptions"
+              />
+            </v-col>
+          </v-row>
+        </v-container>
       </v-card>
     </v-col>
   </v-row>
@@ -100,11 +111,13 @@ export default {
   }),
   computed: {
     datasets: function () {
-      let backGroundColors = this.graphValue.map(element => {
-        return this.graphBackGroundColor[Math.max(Math.ceil(element/2) - 1, 0)]
+      let backGroundColors = this.graphValue.map((element) => {
+        return this.graphBackGroundColor[
+          Math.max(Math.ceil(element / 2) - 1, 0)
+        ]
       })
-      let borderColors = this.graphValue.map(element => {
-        return this.graphBorderColor[Math.max(Math.ceil(element/2) - 1, 0)]
+      let borderColors = this.graphValue.map((element) => {
+        return this.graphBorderColor[Math.max(Math.ceil(element / 2) - 1, 0)]
       })
       return [
         {
@@ -120,8 +133,8 @@ export default {
       switch (this.selectedDoW) {
         case '月曜日':
           return [
-            10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 3, 4, 6, 3, 3, 2, 3, 4, 2, 2, 1, 1, 0,
-            0,
+            10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 3, 4, 6, 3, 3, 2, 3, 4, 2, 2, 1, 1,
+            0, 0,
           ]
         // value = this.$store.state.monday
         case '火曜日':
@@ -191,18 +204,3 @@ export default {
   },
 }
 </script>
-
-<style scoped>
-h2 {
-  display: inline;
-  font-size: 32px;
-}
-h1 {
-  display: inline;
-  font-size: 64px;
-}
-h3 {
-  font-size: 20px;
-  margin-bottom: 10px;
-}
-</style>

--- a/nuxt/components/showgraph.vue
+++ b/nuxt/components/showgraph.vue
@@ -137,47 +137,19 @@ export default {
     graphValue: function () {
       switch (this.selectedDoW) {
         case '月曜日':
-          return [
-            10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 3, 4, 6, 3, 3, 2, 3, 4, 2, 2, 1, 1,
-            0, 0,
-          ]
-        // value = this.$store.state.monday
+          return this.$store.state.monday
         case '火曜日':
-          return [
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 2, 2, 3, 2, 0, 0, 0, 0, 0,
-            0,
-          ]
-        // value = this.$store.state.tuesday
+          return this.$store.state.tuesday
         case '水曜日':
-          return [
-            0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 2, 1, 2, 0, 0, 0, 0, 0,
-            0,
-          ]
-        // value = this.$store.state.wednesday
+          return this.$store.state.wednesday
         case '木曜日':
-          return [
-            0, 0, 0, 0, 0, 0, 0, 2, 2, 0, 0, 3, 3, 2, 1, 1, 1, 3, 3, 2, 0, 0, 0,
-            0,
-          ]
-        // value = this.$store.state.thursday
+          return this.$store.state.thursday
         case '金曜日':
-          return [
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 4, 4, 3, 3, 1, 0, 0, 0, 0, 0, 0, 0,
-            0,
-          ]
-        // value = this.$store.state.friday
+          return this.$store.state.friday
         case '土曜日':
-          return [
-            0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0,
-            0,
-          ]
-        // value = this.$store.state.saturday
+          return this.$store.state.saturday
         case '日曜日':
-          return [
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0,
-          ]
-        // value = this.$store.state.sunday
+          return this.$store.state.sunday
       }
     },
   },

--- a/nuxt/components/shownum.vue
+++ b/nuxt/components/shownum.vue
@@ -10,6 +10,7 @@
             >
           </v-row>
           <v-row justify="center">
+            <!--人数表示部分-->
             <v-card-text
               class="text-center font-weight-bold"
               style="font-size: 2rem"
@@ -21,6 +22,7 @@
             >
           </v-row>
           <v-row justify="center">
+            <!-- 画像表示部分 -->
             <v-card-title>
               <v-img v-bind:src="meterImage" max-width="250px"></v-img>
             </v-card-title>
@@ -74,17 +76,3 @@ export default {
   },
 }
 </script>
-
-<style scoped>
-h2 {
-  display: inline;
-  font-size: 32px;
-}
-h1 {
-  display: inline;
-  font-size: 64px;
-}
-h3 {
-  font-size: 20px;
-}
-</style>

--- a/nuxt/components/shownum.vue
+++ b/nuxt/components/shownum.vue
@@ -1,26 +1,31 @@
 <!--人数表示コンポーネント-->
 <template>
-  <v-row justify="center" align-content="center">
+  <v-row justify="center">
     <v-col :cols="width">
-      <v-card elecaiton="50" class="justify-center" outlined>
-        <v-row align="center">
-          <v-col cols="12">
-            <v-card-text class="text-center">
-              <h3>最終更新時刻：{{ this.$store.state.date }}</h3>
-              <br /><br />
-              <!--人数表示部分-->
-              <h2>現在：</h2>
-              <h1>{{this.$store.state.people }}</h1>
-              <h2>人</h2>
-            </v-card-text>
-            <br />
-            <!-- 画像表示部分 -->
-            <v-row justify="center">
+      <v-card outlined>
+        <v-container>
+          <v-row justify="center">
+            <v-card-title class="font-weight-bold" style="font-size: 1.25rem"
+              >最終更新時刻：{{ this.$store.state.date }}</v-card-title
+            >
+          </v-row>
+          <v-row justify="center">
+            <v-card-text
+              class="text-center font-weight-bold"
+              style="font-size: 2rem"
+              >現在：
+              <span style="font-size: 4rem">{{
+                this.$store.state.people
+              }}</span>
+              人</v-card-text
+            >
+          </v-row>
+          <v-row justify="center">
+            <v-card-title>
               <v-img v-bind:src="meterImage" max-width="250px"></v-img>
-            </v-row>
-            <br />
-          </v-col>
-        </v-row>
+            </v-card-title>
+          </v-row>
+        </v-container>
       </v-card>
     </v-col>
   </v-row>
@@ -52,7 +57,7 @@ export default {
       }
       return this.meterArray[this.$store.state.people]
     },
-    width: function() {
+    width: function () {
       switch (this.$vuetify.breakpoint.name) {
         case 'xs':
           return 11

--- a/nuxt/components/shownum.vue
+++ b/nuxt/components/shownum.vue
@@ -1,7 +1,7 @@
 <!--人数表示コンポーネント-->
 <template>
   <v-row justify="center">
-    <v-col :cols="width">
+    <v-col :cols="cardwidth">
       <v-card outlined>
         <v-container>
           <v-row justify="center">
@@ -36,6 +36,9 @@
 <script>
 export default {
   name: 'ShowNum',
+
+  props: ['cardwidth'],
+
   data: () => ({
     //画像用配列
     meterArray: [
@@ -52,26 +55,13 @@ export default {
       require('@/assets/images/meter_10.png'),
     ],
   }),
+
   computed: {
     meterImage: function () {
       if (this.$store.state.people > 10) {
         return this.meterArray[10]
       }
       return this.meterArray[this.$store.state.people]
-    },
-    width: function () {
-      switch (this.$vuetify.breakpoint.name) {
-        case 'xs':
-          return 11
-        case 'sm':
-          return 8
-        case 'md':
-          return 8
-        case 'lg':
-          return 8
-        case 'xl':
-          return 8
-      }
     },
   },
 }

--- a/nuxt/components/shownum.vue
+++ b/nuxt/components/shownum.vue
@@ -6,7 +6,7 @@
         <v-container>
           <v-row justify="center">
             <v-card-title class="font-weight-bold" style="font-size: 1.25rem"
-              >最終更新時刻：{{ this.$store.state.date }}</v-card-title
+              >最終更新時刻：{{ nowTime }}</v-card-title
             >
           </v-row>
           <v-row justify="center">
@@ -62,6 +62,10 @@ export default {
         return this.meterArray[10]
       }
       return this.meterArray[this.$store.state.people]
+    },
+
+    nowTime: function () {
+      return this.$store.state.date.slice(-8)
     },
   },
 }

--- a/nuxt/components/shownum.vue
+++ b/nuxt/components/shownum.vue
@@ -68,5 +68,9 @@ export default {
       return this.$store.state.date.slice(-8)
     },
   },
+
+  created() {
+    this.$store.dispatch('getPeople')
+  },
 }
 </script>

--- a/nuxt/pages/index.vue
+++ b/nuxt/pages/index.vue
@@ -11,8 +11,8 @@
 </template>
 
 <script>
-import ShowNum from '../components/ShowNum.vue'
-import ShowGraph from '../components/ShowGraph.vue'
+import ShowNum from '/components/shownum.vue'
+import ShowGraph from '/components/showgraph.vue'
 export default {
   components: {
     ShowNum,

--- a/nuxt/pages/index.vue
+++ b/nuxt/pages/index.vue
@@ -4,8 +4,8 @@
       <img :src="require('@/assets/images/title_dot.png')" :height="logosize" />
     </v-toolbar>
     <v-container>
-      <ShowNum style="padding-top: 1em; padding-bottom: 1em" />
-      <ShowGraph style="padding-bottom: 2em" />
+      <ShowNum style="padding-top: 1rem; padding-bottom: 1rem" />
+      <ShowGraph />
     </v-container>
   </div>
 </template>

--- a/nuxt/pages/index.vue
+++ b/nuxt/pages/index.vue
@@ -4,7 +4,7 @@
       <img :src="require('@/assets/images/title_dot.png')" :height="logosize" />
     </v-toolbar>
     <v-container>
-      <ShowNum style="padding-top: 1rem; padding-bottom: 1rem" />
+      <ShowNum class="py-4" />
       <ShowGraph />
     </v-container>
   </div>

--- a/nuxt/pages/index.vue
+++ b/nuxt/pages/index.vue
@@ -1,45 +1,12 @@
 <template>
   <div id="app">
-    <!-- <v-card flat> -->
     <v-toolbar>
       <img :src="require('@/assets/images/title_dot.png')" :height="logosize" />
-      <!-- <template v-slot:extension>
-          <v-tabs
-            color="white"
-            centered
-            fixed-tabs
-            v-model="tab"
-          >
-            <v-tabs-slider color="yellow"></v-tabs-slider>
-            <v-tab v-for="item in items" :key="item.tab">
-              <v-icon>{{ item.tab }}</v-icon>
-            </v-tab>
-          </v-tabs>
-        </template> -->
     </v-toolbar>
     <v-container>
-      <row>
-        <br />
-        <!-- <v-tabs-items v-model="tab">
-        <v-tab-item class="bg"> -->
-        <ShowNum />
-      </row>
-      <!-- </v-tab-item>
-        <v-tab-item class="bg"> -->
-      <row>
-        <br />
-        <br />
-        <ShowGraph />
-        <br />
-        <br />
-      </row>
+      <ShowNum style="padding-top: 1em; padding-bottom: 1em" />
+      <ShowGraph style="padding-bottom: 2em" />
     </v-container>
-    <!-- </v-tab-item>
-        <v-tab-item  class="bg" style="height: 90vh">
-          <h1>工事中！</h1>
-        </v-tab-item>
-      </v-tabs-items> -->
-    <!-- </v-card> -->
   </div>
 </template>
 
@@ -76,7 +43,7 @@ export default {
           return 60
       }
     },
-  }
+  },
 }
 </script>
 

--- a/nuxt/pages/index.vue
+++ b/nuxt/pages/index.vue
@@ -4,8 +4,8 @@
       <img :src="require('@/assets/images/title_dot.png')" :height="logosize" />
     </v-toolbar>
     <v-container>
-      <ShowNum class="py-4" />
-      <ShowGraph />
+      <ShowNum class="py-4" :cardwidth="cardwidth" />
+      <ShowGraph :cardwidth="cardwidth" />
     </v-container>
   </div>
 </template>
@@ -18,7 +18,7 @@ export default {
     ShowNum,
     ShowGraph,
   },
-  
+
   computed: {
     logosize: function () {
       switch (this.$vuetify.breakpoint.name) {
@@ -26,8 +26,16 @@ export default {
           return 40
         case 'sm':
           return 50
-        default: 
+        default:
           return 60
+      }
+    },
+    cardwidth: function () {
+      switch (this.$vuetify.breakpoint.name) {
+        case 'xs':
+          return 11
+        default:
+          return 8
       }
     },
   },

--- a/nuxt/pages/index.vue
+++ b/nuxt/pages/index.vue
@@ -47,19 +47,6 @@ export default {
 }
 </script>
 
-<style scoped>
-h1 {
-  color: #000;
-}
-.bg {
-  top: 0;
-  left: 0;
-  height: 110hv;
-  background-size: cover;
-  background-image: url('~@/assets/images/bg_bar.png');
-}
-</style>
-
 <style lang="scss">
 .v-application {
   font-family: 'DotsFont';

--- a/nuxt/pages/index.vue
+++ b/nuxt/pages/index.vue
@@ -18,16 +18,7 @@ export default {
     ShowNum,
     ShowGraph,
   },
-  data: () => ({
-    drawer: false,
-    group: null,
-    tab: 0,
-    items: [
-      { tab: 'mdi-human-greeting' },
-      { tab: 'mdi-equalizer' },
-      { tab: 'mdi-google-downasaur' },
-    ],
-  }),
+  
   computed: {
     logosize: function () {
       switch (this.$vuetify.breakpoint.name) {
@@ -35,11 +26,7 @@ export default {
           return 40
         case 'sm':
           return 50
-        case 'md':
-          return 60
-        case 'lg':
-          return 60
-        case 'xl':
+        default: 
           return 60
       }
     },

--- a/nuxt/store/index.js
+++ b/nuxt/store/index.js
@@ -1,76 +1,88 @@
-import axios from "axios";
+import axios from 'axios'
 
 export const state = () => ({
-    //変数置き
-    people: 0,
-    monday:[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    tuesday:[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    wednesday:[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    thursday:[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    friday:[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    saturday:[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    sunday:[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    date: 0,
+  //変数置き
+  people: 0,
+  monday: [
+    10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 3, 4, 6, 3, 3, 2, 3, 4, 2, 2, 1, 1, 0, 0,
+  ],
+  tuesday: [
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 2, 2, 3, 2, 0, 0, 0, 0, 0, 0,
+  ],
+  wednesday: [
+    0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 2, 1, 2, 0, 0, 0, 0, 0, 0,
+  ],
+  thursday: [
+    0, 0, 0, 0, 0, 0, 0, 2, 2, 0, 0, 3, 3, 2, 1, 1, 1, 3, 3, 2, 0, 0, 0, 0,
+  ],
+  friday: [
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 4, 4, 3, 3, 1, 0, 0, 0, 0, 0, 0, 0, 0,
+  ],
+  saturday: [
+    0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  ],
+  sunday: [
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  ],
+  date: '2021-10-01 10:00:00',
 })
 
 export const mutations = {
-
-    setPeople(state, num) {
-        state.people = num;
-    },
-    setGraphMon(state, vals){
-        state.monday = vals;
-    },
-    setGraphTue(state, vals){
-        state.tuesday = vals;
-    },
-    setGraphWed(state, vals){
-        state.wednesday = vals;
-    },
-    setGraphThu(state, vals){
-        state.thursday = vals;
-    },
-    setGraphFri(state, vals){
-        state.friday = vals;
-    },
-    setGraphSat(state, vals){
-        state.saturday = vals;
-    },
-    setGraphSun(state, vals){
-        state.sunday = vals;
-    },
-    setDate(state, date){
-        state.date = date;
-    }
+  setPeople(state, num) {
+    state.people = num
+  },
+  setGraphMon(state, vals) {
+    state.monday = vals
+  },
+  setGraphTue(state, vals) {
+    state.tuesday = vals
+  },
+  setGraphWed(state, vals) {
+    state.wednesday = vals
+  },
+  setGraphThu(state, vals) {
+    state.thursday = vals
+  },
+  setGraphFri(state, vals) {
+    state.friday = vals
+  },
+  setGraphSat(state, vals) {
+    state.saturday = vals
+  },
+  setGraphSun(state, vals) {
+    state.sunday = vals
+  },
+  setDate(state, date) {
+    state.date = date
+  },
 }
 
 export const actions = {
-    async getPeople(context) {
-        await axios
-            .get('http://localhost:8081/people')
-            .then((res) => {
-                context.commit("setPeople", res.data.people);//コ↑コ↓　わからん
-                context.commit("setDate", res.data.date);
-            })
-            .catch(() => {
-                console.log("peopelの取得が失敗しました。")
-            });
-    },
-    async getGraphVal(context) {
-        await axios
-            .get('http://localhost:8081/graph')
-            .then((res) => {
-                context.commit("setGraphMon", res.data.monday);
-                context.commit("setGraphTue", res.data.tuesday);
-                context.commit("setGraphWed", res.data.wednesday);
-                context.commit("setGraphThu", res.data.thursday);
-                context.commit("setGraphFri", res.data.friday);
-                context.commit("setGraphSat", res.data.saturday);
-                context.commit("setGraphSun", res.data.sunday);
-            })
-            .catch(() => {
-                console.log("graphの取得が失敗しました。")
-            });
-    },
+  async getPeople(context) {
+    await axios
+      .get('http://localhost:8081/people')
+      .then((res) => {
+        context.commit('setPeople', res.data.people) //コ↑コ↓　わからん
+        context.commit('setDate', res.data.date)
+      })
+      .catch(() => {
+        console.log('peopelの取得に失敗しました。')
+      })
+  },
+  async getGraphVal(context) {
+    await axios
+      .get('http://localhost:8081/graph')
+      .then((res) => {
+        context.commit('setGraphMon', res.data.monday)
+        context.commit('setGraphTue', res.data.tuesday)
+        context.commit('setGraphWed', res.data.wednesday)
+        context.commit('setGraphThu', res.data.thursday)
+        context.commit('setGraphFri', res.data.friday)
+        context.commit('setGraphSat', res.data.saturday)
+        context.commit('setGraphSun', res.data.sunday)
+      })
+      .catch(() => {
+        console.log('graphの取得に失敗しました。')
+      })
+  },
 }
-


### PR DESCRIPTION
の以上2つを行いました．各ファイルの修正点について述べていきます．
## index.vue
### refact
- brからclassによるスタイリングへの変更
    - Vuetifyそのものに物体と物体の距離を設定するヘルパークラスがあったのでそれを使用しました．詳しくは https://vuetifyjs.com/ja/styles/spacing/ を参照してください．
- computed: cardwidthの追加
    - 全てのカードの横幅をindex.vueで管理するように変更しました．
- 未使用のdataの削除
- logosizeの修正
    - defaultを使用しコードを短縮しました．
- 不要なstyleの削除
### fix
- importのバグの修正
    - VSCodeでindex.vueで文法エラーが発生する不具合に対処しました．

## shownum.vue
### refact
- 構造の変更
    - v-rowは行，v-colは列という考え方に従って書き直してみました．
- 最終更新時刻の構造変更
    - v-card-titleを使用しました．v-card-titleには，それ自体にセンタリングの効果があります．それをboldにした後でフォントサイズを設定しました．
- 人数表示部分の構造変更
    - v-card-textでないと不格好になるため，こちらを使用しました．センタリング，bold，フォントサイズの設定を行なっています．また，spanで人数部分だけフォントサイズを大きくしました．
- ゲージ表示部分の構造変更
    - センタリングのためにv-card-titleを使用しています．
- props: cardwidthの追加
    - index.vueからcardwidthを受け取るためのものです．
- 不要なstyleの削除

### feat
- computed: nowTimeの追加
    - 日付から時刻を抽出する関数です(2021-10-01 10:00:00 → 10:00:00)
    - バックエンドの都合でまともなテストができていないので，後で修正が入るかも．
- 起動時にバックエンドから人数を取得する処理の追加
    - createdを参照

## showgraph.vue
### refact
- 構造の変更
    - v-rowは行，v-colは列という考え方に従って書き直してみました．
- 【人数予想】
    - mb-n2はスタイリングのためのヘルパークラスです
- v-select
    - mb-n8も同様
    - 【人数予想】と行を分けたことにより，ページの横幅を細くした際に【人数予想】が歪むことがなくなりました．
- props: cardwidthの追加
- 不要なstyleの削除

### feat
- グラフのテストデータをindex.jsに移動
- 起動時にバックエンドからグラフデータを取得する処理の追加
    - createdを参照

## index.js
### feat
- showgraph.vueのグラフのテストデータをstateに移植
- dateの初期値を適切なものに変更